### PR TITLE
Fix routing problem

### DIFF
--- a/fastapi_restful/cbv.py
+++ b/fastapi_restful/cbv.py
@@ -86,7 +86,6 @@ def _init_cbv(cls: Type[Any], instance: Any = None) -> None:
 
 
 def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
-    cbv_router = APIRouter()
     function_members = inspect.getmembers(cls, inspect.isfunction)
     for url in urls:
         _allocate_routes_by_method_name(router, url, function_members)
@@ -107,10 +106,7 @@ def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
         if isinstance(route, (Route, WebSocketRoute)) and route.endpoint in functions_set
     ]
     for route in cbv_routes:
-        router.routes.remove(route)
         _update_cbv_route_endpoint_signature(cls, route)
-        cbv_router.routes.append(route)
-    router.include_router(cbv_router)
 
 
 def _allocate_routes_by_method_name(router: APIRouter, url: str, function_members: List[Tuple[str, Any]]) -> None:

--- a/tests/test_cbv.py
+++ b/tests/test_cbv.py
@@ -82,3 +82,18 @@ def test_multiple_decorators() -> None:
     assert client.get("/items").json() == []
     assert client.get("/items/1").json() == {"item_path": "1"}
     assert client.get("/database/abc").json() == {"item_path": "abc"}
+
+
+def test_prefix() -> None:
+    router = APIRouter(prefix="/api")
+
+    @cbv(router)
+    class RootHandler:
+        @router.get("/item")
+        def root(self) -> str:
+            return "hello"
+
+    client = TestClient(router)
+    response = client.get("/api/item")
+    assert response.status_code == 200
+    assert response.json() == "hello"


### PR DESCRIPTION
Original issue: https://github.com/dmontagu/fastapi-utils/issues/154

Credit: WouldYouKindly <https://github.com/WouldYouKindly>

If we use class-based routing, the cbv causes the double routes.
WouldYouKindly solves the problem, but he does not the patch to the
repo. I really need the patch for my daily development so I copy his
solution to resolve.

If it causes anyone feels uncomfortable, I will delete my PR.

Sorry for the copy