### PR TITLE
fix: Allow empty path when prefix is set

### DIFF
--- a/fastapi_restful/cbv.py
+++ b/fastapi_restful/cbv.py
@@ -86,7 +86,7 @@ def _init_cbv(cls: Type[Any], instance: Any = None) -> None:
 
 
 def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
-    cbv_router = APIRouter()
+    cbv_router = APIRouter(prefix=router.prefix)
     function_members = inspect.getmembers(cls, inspect.isfunction)
     for url in urls:
         _allocate_routes_by_method_name(router, url, function_members)
@@ -112,7 +112,11 @@ def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
         route.path = route.path[prefix_length:]
         _update_cbv_route_endpoint_signature(cls, route)
         cbv_router.routes.append(route)
-    router.include_router(cbv_router)
+    # Tempory remove prefix to by pass the prefix check and allow
+    # allow empty root method with a prefix
+    router.prefix = ""
+    router.include_router(cbv_router, prefix=cbv_router.prefix)
+    router.prefix = cbv_router.prefix
 
 
 def _allocate_routes_by_method_name(router: APIRouter, url: str, function_members: List[Tuple[str, Any]]) -> None:

--- a/tests/test_cbv.py
+++ b/tests/test_cbv.py
@@ -1,5 +1,6 @@
 from typing import Any, ClassVar
 
+import pytest
 from fastapi import APIRouter, Depends, FastAPI
 from starlette.testclient import TestClient
 
@@ -97,3 +98,33 @@ def test_prefix() -> None:
     response = client.get("/api/item")
     assert response.status_code == 200
     assert response.json() == "hello"
+
+
+def test_prefix_and_empty_route() -> None:
+    router = APIRouter(prefix="/api")
+
+    @cbv(router)
+    class RootHandler:
+        @router.get("")
+        def root(self) -> str:
+            return "hello"
+
+    client = TestClient(router)
+    response = client.get("/api")
+    assert response.status_code == 200
+    assert response.json() == "hello"
+
+
+def test_no_prefix_and_empty_route_raises() -> None:
+    router = APIRouter()
+
+    with pytest.raises(Exception):
+
+        @cbv(router)
+        class RootHandler:
+            @router.get("")
+            def root(self) -> str:
+                return "hello"
+
+        client = TestClient(router)
+        client.get("/api")


### PR DESCRIPTION
Original issue : https://github.com/dmontagu/fastapi-utils/issues/85

It's very hacky, but I could not figure out another way to do it. Another solution I had was to directly use the `router.add_api_route()` but this method have a lot arguments and it was requiring to also support `WebsocketsRoute`

