### PR TITLE
Fix tag duplication when using cbv

### DIFF
--- a/fastapi_restful/cbv.py
+++ b/fastapi_restful/cbv.py
@@ -112,11 +112,12 @@ def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
     for route in cbv_routes:
         router.routes.remove(route)
         # remove any tags that were previously assigned by router to route
-        for tag in router.tags:
-            try:
-                route.tags.remove(tag)
-            except ValueError:
-                pass
+        if isinstance(route, APIRoute):
+            for tag in router.tags:
+                try:
+                    route.tags.remove(tag)
+                except ValueError:
+                    pass
         route.path = route.path[prefix_length:]
         _update_cbv_route_endpoint_signature(cls, route)
         cbv_router.routes.append(route)

--- a/fastapi_restful/cbv.py
+++ b/fastapi_restful/cbv.py
@@ -111,6 +111,12 @@ def _register_endpoints(router: APIRouter, cls: Type[Any], *urls: str) -> None:
     prefix_length = len(router.prefix)  # Until 'black' would fix an issue which causes PEP8: E203
     for route in cbv_routes:
         router.routes.remove(route)
+        # remove any tags that were previously assigned by router to route
+        for tag in router.tags:
+            try:
+                route.tags.remove(tag)
+            except ValueError:
+                pass
         route.path = route.path[prefix_length:]
         _update_cbv_route_endpoint_signature(cls, route)
         cbv_router.routes.append(route)


### PR DESCRIPTION
Fixes:  https://github.com/yuval9313/FastApi-RESTful/issues/192

I don't really like the way that `_register_endpoints` looks.  It feels overly complicated, and there are some oddities, like whether or not `APIWebsocketRoute` is valid as a route or not?

Nevertheless, this fixes an issue with ReDoc and the duplication of tags when using class-based views.
