### PR TITLE
fix: fix ci not run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,5 +49,7 @@ jobs:
         # only run this for the python version used by netlify:
         if: matrix.python-version == '3.10'
         run: poetry run make docs-build
-      - name: Check that formatting, linting, and tests pass
-        run: poetry run make ci
+      - name: Check that formatting, linting, and tests pass for pydantic v1
+        run: poetry run make ci-v1
+      - name: Check that formatting, linting, and tests pass for pydantic v2
+        run: poetry run make ci-v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Install dependencies
         run: poetry install -E session
 
-      - name: Check that formatting, linting, and tests pass
-        run: poetry run make ci
+      - name: Check that formatting, linting, and tests pass for pydantic v1
+        run: poetry run make ci-v1
+      - name: Check that formatting, linting, and tests pass for pydantic v2
+        run: poetry run make ci-v2
 
       - name: Check docs are up to date
         run: poetry run make docs-build


### PR DESCRIPTION
We missed these CI steps for pydantic v2 changes. This fixes it. Hopefully this allows you to create a release.